### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Aleksandr Kovalev <aleksandr@kovalev.engineer>"]
 description = "a database"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/sanchopanca/quicksave"
 
 
 [dependencies]


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it